### PR TITLE
Small Improvement for predict.py's Handling of Weight Files

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -2,6 +2,7 @@
     trained neural network """
 import pickle
 import numpy
+import sys
 from music21 import instrument, note, stream, chord
 from keras.models import Sequential
 from keras.layers import Dense
@@ -67,7 +68,8 @@ def create_network(network_input, n_vocab):
     model.compile(loss='categorical_crossentropy', optimizer='rmsprop')
 
     # Load the weights to each node
-    model.load_weights('weights.hdf5')
+    weight_source = sys.argv[1] or 'weights.hdf5'
+    model.load_weights(weight_source)
 
     return model
 


### PR DESCRIPTION
Modified predict.py to allow for the contextually used weights file to be specified as a command line argument.