### PR TITLE
Make `predict.py` work out-of-the-box

### DIFF
--- a/predict.py
+++ b/predict.py
@@ -71,7 +71,7 @@ def create_network(network_input, n_vocab):
     model.compile(loss='categorical_crossentropy', optimizer='rmsprop')
 
     # Load the weights to each node
-    model.load_weights('weights-improvement-195-0.1490-bigger.hdf5')
+    model.load_weights('weights.hdf5')
 
     return model
 


### PR DESCRIPTION
Previously, `predict.py` pointed to a file that is not in the main repository.

This commit updates `predict.py` to point to the existing `weights.hdf5`, the most recently updated weights file as of this commit.